### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ For more crypto-related MCP servers, see the [Kukapay MCP servers](https://githu
 
    Check the document [here](https://www.freqtrade.io/en/stable/rest-api/#configuration).
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kukapay-freqtrade-mcp).
+
 ## Usage
 
 ### Available Tools


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kukapay-freqtrade-mcp).